### PR TITLE
Add https support for Heroku

### DIFF
--- a/astroBotSlack.js
+++ b/astroBotSlack.js
@@ -2,9 +2,14 @@ var Slack = require('slack-client');
 var request = require('request');
 var express = require('express');
 var http = require('http');
+var https = require('https');
 var config = require('./config');
 setInterval(function () {
-  http.get(config.heroku.url);
+  if (config.heroku.url.substring(0, 5) == 'https') {
+    https.get(config.heroku.url);
+  } else {
+    http.get(config.heroku.url);
+  }
 }, (config.heroku.checkInterval * 60) * 1000); // every 5 minutes(300000)
 
 // Unique token for the AstroBot

--- a/astroBotSlack.js
+++ b/astroBotSlack.js
@@ -5,7 +5,7 @@ var http = require('http');
 var https = require('https');
 var config = require('./config');
 setInterval(function () {
-  if (config.heroku.url.substring(0, 5) == 'https') {
+  if (config.heroku.url.substring(0, 5) === 'https') {
     https.get(config.heroku.url);
   } else {
     http.get(config.heroku.url);


### PR DESCRIPTION
Since Heroku urls can be https, this PR adds support for them using the built-in module, `https` 

Closes #17 